### PR TITLE
HE-8: Add DELETE game API endpoint

### DIFF
--- a/csharp/src/api/Controllers/GamesController.cs
+++ b/csharp/src/api/Controllers/GamesController.cs
@@ -55,6 +55,31 @@ public partial class GamesController(IIdentifierGenerator identifierGenerator) :
         return Ok(game);
     }
 
+    [HttpDelete("{gameId:guid}")]
+    public ActionResult DeleteGame([FromRoute] Guid gameId)
+    {
+        var game = RetrieveGame(gameId);
+        
+        if (game == null)
+        {
+            return NotFound(new ResponseErrorViewModel
+            {
+                Message = "Game not found"
+            });
+        }
+
+        if (game.Status == "Won" || game.Status == "Lost")
+        {
+            return BadRequest(new ResponseErrorViewModel
+            {
+                Message = "Cannot delete completed games"
+            });
+        }
+
+        Games.Remove(gameId);
+        return NoContent();
+    }
+
     private static GameViewModel? RetrieveGame(Guid gameId)
     {
         return Games.GetValueOrDefault(gameId);

--- a/java/app/src/main/java/hangman/App.java
+++ b/java/app/src/main/java/hangman/App.java
@@ -19,6 +19,7 @@ public class App {
         post("/games/", (request, response) -> gamesController.createGame());
         get("/games/:game_id", (request, response) -> gamesController.getGame(request, response), new JsonTransformer());
         post("/games/:game_id/guesses", "application/json", (request, response) -> gamesController.makeGuess(request, response), new JsonTransformer());
+        delete("/games/:game_id", (request, response) -> gamesController.deleteGame(request, response));
 
         // handle illegal arguments.
         exception(IllegalArgumentException.class, (e, req, res) -> {

--- a/java/app/src/main/java/hangman/controllers/GamesController.java
+++ b/java/app/src/main/java/hangman/controllers/GamesController.java
@@ -56,6 +56,27 @@ public class GamesController {
         return null;
     }
 
+    public String deleteGame(Request request, Response response) {
+        var gameArgument = request.params("game_id");
+        var gameId = UUID.fromString(gameArgument);
+        
+        if (gameId == null || !games.containsKey(gameId)) {
+            response.status(404);
+            return "";
+        }
+
+        var game = games.get(gameId);
+        
+        if ("Won".equals(game.getStatus()) || "Lost".equals(game.getStatus())) {
+            response.status(400);
+            return "";
+        }
+
+        games.remove(gameId);
+        response.status(204);
+        return "";
+    }
+
     private static String retrieveWord() {
         var rand = new Random();
         return words.get(rand.nextInt(words.size() - 3));

--- a/java/app/src/main/java/hangman/models/Game.java
+++ b/java/app/src/main/java/hangman/models/Game.java
@@ -24,4 +24,8 @@ public class Game {
         status = "In Progress";
         incorrectGuesses = new ArrayList<>();
     }
+
+    public String getStatus() {
+        return status;
+    }
 }

--- a/typescript/controllers/games.ts
+++ b/typescript/controllers/games.ts
@@ -43,6 +43,28 @@ function makeGuess(req: Request, res: Response) {
   res.status(200).json(clearUnmaskedWord(game));
 }
 
+function deleteGame(req: Request, res: Response) {
+  const { gameId } = req.params;
+  const game = retrieveGame(gameId);
+
+  if (!game) {
+    res.status(404).json({
+      message: "Game not found",
+    });
+    return;
+  }
+
+  if (game.status === "Won" || game.status === "Lost") {
+    res.status(400).json({
+      message: "Cannot delete completed games",
+    });
+    return;
+  }
+
+  delete games[gameId];
+  res.status(204).send();
+}
+
 const retrieveGame = (gameId: string) => games[gameId];
 
 const retrieveWord = () => words[Math.ceil(1 * words.length - 1)];
@@ -59,6 +81,7 @@ const GamesController = {
   createGame,
   getGame,
   makeGuess,
+  deleteGame,
 };
 
 export { GamesController };

--- a/typescript/routers/games.ts
+++ b/typescript/routers/games.ts
@@ -5,5 +5,6 @@ const GamesRouter = Router();
 GamesRouter.route("/").post(GamesController.createGame);
 GamesRouter.route("/:gameId").get(GamesController.getGame);
 GamesRouter.route("/:gameId").put(GamesController.makeGuess);
+GamesRouter.route("/:gameId").delete(GamesController.deleteGame);
 
 export { GamesRouter };


### PR DESCRIPTION
## Summary
- Implemented DELETE `/games/{gameId}` endpoint across all three language implementations
- Added validation to only allow deletion of "In Progress" games per acceptance criteria
- Returns appropriate HTTP status codes (204, 400, 404)

## Implementation Details

### TypeScript
- Added `deleteGame` function to `controllers/games.ts`
- Added DELETE route to `routers/games.ts`

### C#
- Added `HttpDelete` action to `GamesController.cs`
- Uses existing `RetrieveGame` method for consistency

### Java  
- Added `deleteGame` method to `GamesController.java`
- Added getter for game status in `Game.java` model
- Added DELETE route to Spark application

## Testing
Ready for testing with existing Postman collection which includes:
- Delete valid game (expects 204)
- Delete invalid/non-existent game (expects 404)
- Validation of game status restrictions

## Related
- Jira Issue: [HE-8](https://unosquare.atlassian.net/browse/HE-8)
- Status: Currently in QA

🤖 Generated with [Claude Code](https://claude.ai/code)